### PR TITLE
Fixed compiler warnings and fixed instantiation via NIB

### DIFF
--- a/TDBadgedCell (xcode project)/TDBadgedCell.m
+++ b/TDBadgedCell (xcode project)/TDBadgedCell.m
@@ -98,8 +98,7 @@
 
 @synthesize badgeString, badge, badgeColor, badgeColorHighlighted;
 
-- (id)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
-    if ((self = [super initWithStyle:style reuseIdentifier:reuseIdentifier])) {
+- (void)configureSelf {
         // Initialization code
 		badge = [[TDBadgeView alloc] initWithFrame:CGRectZero];
 		badge.parent = self;
@@ -113,6 +112,18 @@
 			[self.contentView addSubview:self.badge];
 		
 		[self.badge setNeedsDisplay];
+}
+
+- (id)initWithCoder:(NSCoder *)decoder {
+    if ((self = [super initWithCoder:decoder])) {
+        [self configureSelf];
+    }
+    return self;
+}
+
+- (id)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    if ((self = [super initWithStyle:style reuseIdentifier:reuseIdentifier])) {
+        [self configureSelf];
     }
     return self;
 }


### PR DESCRIPTION
I've got strict compiler warnings turned on. I fixed a bunch of compiler warnings, mostly by casting and clarifying some floats.

I also implemented the `initWithCoder:` method to enable using a TDBadgedCell subclass in a nib file.
