### PR TITLE
Add badge font size

### DIFF
--- a/TDBadgedCell (xcode project)/Classes/RootViewController.m
+++ b/TDBadgedCell (xcode project)/Classes/RootViewController.m
@@ -94,7 +94,6 @@
 	
 	cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
 	cell.badgeString = [[contents objectAtIndex:indexPath.row] objectForKey:@"badge"];
-	
 	if (indexPath.row == 1)
 		cell.badgeColor = [UIColor colorWithRed:0.792 green:0.197 blue:0.219 alpha:1.000];
 	

--- a/TDBadgedCell (xcode project)/TDBadgedCell.h
+++ b/TDBadgedCell (xcode project)/TDBadgedCell.h
@@ -43,6 +43,7 @@
 @property (nonatomic, TD_STRONG)    UIColor *badgeColor;
 @property (nonatomic, TD_STRONG)    UIColor *badgeTextColor;
 @property (nonatomic, TD_STRONG)    UIColor *badgeColorHighlighted;
+@property (nonatomic, assign)       CGFloat badgeTextFontSize;
 @property (nonatomic, assign)       BOOL showShadow;
 @property (nonatomic, assign)       CGFloat radius;
 
@@ -57,6 +58,7 @@
 @property (nonatomic, TD_STRONG)    UIColor *badgeColor;
 @property (nonatomic, TD_STRONG)    UIColor *badgeTextColor;
 @property (nonatomic, TD_STRONG)    UIColor *badgeColorHighlighted;
+@property (nonatomic, assign)       CGFloat badgeTextFontSize;
 @property (nonatomic, assign)       BOOL showShadow;
 
 @end

--- a/TDBadgedCell (xcode project)/TDBadgedCell.m
+++ b/TDBadgedCell (xcode project)/TDBadgedCell.m
@@ -20,9 +20,11 @@
     #define TDLineBreakModeClip UILineBreakModeClip
 #endif
 
+#define kDefaultFontSize 11.0
+
 @implementation TDBadgeView
 
-@synthesize width=__width, badgeString=__badgeString, parent=__parent, badgeColor=__badgeColor, badgeTextColor=__badgeTextColor, badgeColorHighlighted=__badgeColorHighlighted, showShadow=__showShadow, radius=__radius;
+@synthesize width=__width, badgeString=__badgeString, parent=__parent, badgeColor=__badgeColor, badgeTextColor=__badgeTextColor, badgeColorHighlighted=__badgeColorHighlighted, showShadow=__showShadow, radius=__radius, badgeTextFontSize=__badgeTextFontSize;
 
 - (id) initWithFrame:(CGRect)frame
 {
@@ -36,8 +38,10 @@
 
 - (void) drawRect:(CGRect)rect
 {		
-    CGFloat fontsize = 11;
-    
+  CGFloat fontsize = kDefaultFontSize;
+  if (__badgeTextFontSize)
+    fontsize = __badgeTextFontSize;
+  
 	CGSize numberSize = [self.badgeString sizeWithFont:[UIFont boldSystemFontOfSize: fontsize]];
 		
 	CGRect bounds = CGRectMake(0 , 0, numberSize.width + 12 , 18);
@@ -152,7 +156,7 @@
 
 @implementation TDBadgedCell
 
-@synthesize badgeString, badge=__badge, badgeColor, badgeTextColor, badgeColorHighlighted, showShadow;
+@synthesize badgeString, badge=__badge, badgeColor, badgeTextColor, badgeColorHighlighted, showShadow, badgeTextFontSize=__badgeTextFontSize;
 
 #pragma mark - Init methods
 
@@ -198,12 +202,14 @@
 		else
 			[self.badge setHidden:NO];
 		
-		
-		CGSize badgeSize = [self.badgeString sizeWithFont:[UIFont boldSystemFontOfSize: 11]];
+		CGFloat fontSize = kDefaultFontSize;
+    if (__badgeTextFontSize)
+      fontSize = __badgeTextFontSize;
+		CGSize badgeSize = [self.badgeString sizeWithFont:[UIFont boldSystemFontOfSize: fontSize]];
 		CGRect badgeframe = CGRectMake(self.contentView.frame.size.width - (badgeSize.width + 25),
                                 (CGFloat)round((self.contentView.frame.size.height - 18) / 2),
                                 badgeSize.width + 13,
-                                18);
+                                badgeSize.height + 4);
 		
         if(self.showShadow)
             [self.badge setShowShadow:YES];
@@ -241,7 +247,9 @@
 
 		if(self.badgeTextColor)
 			self.badge.badgeTextColor = self.badgeTextColor;
-
+    
+    if (self.badgeTextFontSize)
+      self.badge.badgeTextFontSize = __badgeTextFontSize;
 	}
 	else
 	{


### PR DESCRIPTION
Hi, 

I've made this little tiny fix allowing the user to change the badge font size. Seems to produce exactly the same result as before when not using the new property.

Looks like this with the sample project when the new setting is not used:

![Screen Shot 2012-12-13 at 2 41 23 PM](https://f.cloud.github.com/assets/271047/10638/d7029af6-452a-11e2-8861-242cc291589c.png)

When setting :

```
    cell.badgeTextFontSize = 15.0;
```

It looks like this :
![Screen Shot 2012-12-13 at 2 41 46 PM](https://f.cloud.github.com/assets/271047/10640/dbca4cb4-452a-11e2-9cc1-713d6cfb5db9.png)

An even  better solution would be to center the label vertically since it is slightly too low with fonts higher than 11 (which is the default size)
