### PR TITLE
Offsets not being applied

### DIFF
--- a/TDBadgedCell (xcode project)/TDBadgedCell.m
+++ b/TDBadgedCell (xcode project)/TDBadgedCell.m
@@ -190,6 +190,8 @@
 	
 	if(self.badgeString)
 	{
+        [[self contentView] addSubview:[self badge]];
+        
 		// Force badges to hide on edit.
 		if(self.editing)
 			[self.badge setHidden:YES];


### PR DESCRIPTION
Calling `-configureSelf` in `-layoutSubviews` resets the default offsets. Not sure if this is the best fix, but seems to work. The demo now correctly shows the offset applied by:

```
if (indexPath.row == 1) {
    cell.badgeColor = [UIColor colorWithRed:0.792 green:0.197 blue:0.219 alpha:1.000];
    cell.badge.fontSize = 16;
    cell.badgeLeftOffset = 8;
    cell.badgeRightOffset = 40;
}
```

See:

![screen shot 2013-06-07 at 13 43 32](https://f.cloud.github.com/assets/625199/623681/e167314e-cf6f-11e2-8c47-ea511a792555.png)
