### PR TITLE
Enable ARC by default

### DIFF
--- a/TDBadgedCell (xcode project)/TDBadgedTableCell.xcodeproj/project.pbxproj
+++ b/TDBadgedCell (xcode project)/TDBadgedTableCell.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_ENABLE_OBJC_ARC = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
@@ -234,6 +235,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_ENABLE_OBJC_ARC = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;


### PR DESCRIPTION
When `CLANG_ENABLE_OBJC_ARC` is set to NO in this project, ARC projects using it via CocoaPods are calling the `dealloc` method in `TDBadgedCell.m`. This leads to `EXC_BAD_ACCESS` errors as it tries to release objects that it shouldn't when moving away from the controller using TDBadgedCell.
