### PR TITLE
Requires ARC for Cocoapods

### DIFF
--- a/TDBadgedCell.podspec
+++ b/TDBadgedCell.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
 
   s.platform = :ios
   s.source_files = 'TDBadgedCell (xcode project)/TDBadgedCell.{h,m}'
-
+  s.requires_arc = true
   s.frameworks = 'QuartzCore'
 end


### PR DESCRIPTION
This would be a nice thing to have in the main repo.  By default, installing through Cocoapods causes crashes at runtime.
