### PR TITLE
Fix regression in 30fa296: Missing badgeRightOffset.

### DIFF
--- a/TDBadgedCell (xcode project)/TDBadgedCell.m
+++ b/TDBadgedCell (xcode project)/TDBadgedCell.m
@@ -150,6 +150,16 @@
 	if ((self = [super initWithStyle:style reuseIdentifier:reuseIdentifier]))
 	{
         self.badgeLeftOffset = 10.f;
+        
+        if (self.accessoryType != UITableViewCellAccessoryNone)
+        {
+            self.badgeRightOffset = 0.f;
+        }
+        else
+        {
+            self.badgeRightOffset = 12.f;
+        }
+
 		[self configureSelf];
 	}
 	return self;


### PR DESCRIPTION
This change fixes a regression introduced in 30fa296, which had the pre-iOS 7 code path for setting badgeRightOffset.