### PR TITLE
Fix labels not being resized.

### DIFF
--- a/TDBadgedCell (xcode project)/TDBadgedCell.m
+++ b/TDBadgedCell (xcode project)/TDBadgedCell.m
@@ -232,14 +232,14 @@
 		[self.badge setBadgeString:self.badgeString];
 		
         // Resize all labels
-        /*for (UILabel *label in self.resizeableLabels)
+        for (UILabel *label in self.resizeableLabels)
         {
             if ((label.frame.origin.x + label.frame.size.width) >= badgeframe.origin.x)
             {
                 CGFloat textLabelWidth = badgeframe.origin.x - label.frame.origin.x - self.badgeLeftOffset;
                 label.frame = CGRectMake(label.frame.origin.x, label.frame.origin.y, textLabelWidth, label.frame.size.height);
             }
-        }*/
+        }
 		
 		//set badge colours
 		if(self.badgeColorHighlighted)


### PR DESCRIPTION
Fix for labels no longer being resized.

This appears to be a regression introduced in commit 7859d5ab100cc918f22b0c4a564e2ff78759607a.